### PR TITLE
Release 1.0.8

### DIFF
--- a/.prompts/upgrade.md
+++ b/.prompts/upgrade.md
@@ -1,0 +1,223 @@
+WHISPER_VERSION = v1.9.2
+BUCKY_VERSION = v1.0.8
+
+Upgrade this Bucky repository to whisper.cpp <WHISPER_VERSION> and prepare
+Bucky release <BUCKY_VERSION>.
+
+Use the latest published Bucky tag before this work as the release-note
+baseline. If <BUCKY_VERSION> already exists locally or on the remote, do not
+move or replace the tag. Stop and select/recommend the next unused patch
+version instead.
+
+Carry the upgrade through implementation, runtime validation, benchmarks,
+documentation, and release notes. Do not only change the version string.
+
+## Preflight
+
+1. Inspect git status and preserve unrelated worktree changes.
+2. Inspect local and remote Bucky tags.
+3. Identify the currently pinned whisper.cpp version.
+4. Confirm that ardanlabs/bucky-builder has completed the required
+   <WHISPER_VERSION> artifacts:
+   - macOS Metal universal
+   - Windows CPU amd64
+   - Linux CPU amd64 and arm64
+   - Linux CUDA amd64 and arm64
+   - Linux Vulkan amd64 and arm64
+5. Confirm any Windows CUDA artifact still obtained directly from upstream is
+   available and that its fixed filename/version remains correct.
+6. If required release assets are unavailable, report the missing artifacts
+   and do not update the default yet.
+
+## FFI and ABI audit
+
+Compare ggml-org/whisper.cpp's public `include/whisper.h` between the current
+pinned tag and <WHISPER_VERSION>.
+
+Audit every ABI-sensitive type and function used by `pkg/whisper`, including:
+
+- `whisper_context_params`
+- `whisper_full_params`
+- `whisper_token_data`
+- `whisper_vad_params`
+- `whisper_vad_context_params`
+- enums used as FFI integers
+- callback typedefs
+- every function prepared through `lib.Prep`
+
+Identify:
+
+- struct fields added, removed, reordered, or retyped
+- changed enum values
+- changed function parameters or return types
+- removed or renamed symbols
+- newly added APIs that are optional rather than required for compatibility
+- expected 64-bit struct sizes and alignment
+
+Make the smallest required FFI changes. Do not add bindings for optional new
+features unless needed for compatibility or clearly valuable to Bucky's
+existing API.
+
+Update the upgrade tests when layouts change. Ensure the tests verify
+by-value and by-reference parameter handling where applicable.
+
+## Pinned version and download matrix
+
+Update all places that establish or describe the default whisper.cpp version,
+including:
+
+- `pkg/download.DefaultWhisperVersion`
+- platform download-matrix tests
+- installer CLI help
+- Makefile examples
+- README architecture/version references
+- INSTALL source-build instructions
+- relevant comments and examples
+- CI behavior that relies on the default
+
+Add or update an exact regression test asserting that
+`DefaultWhisperVersion` equals <WHISPER_VERSION>.
+
+Do not remove tests proving that explicitly requested older valid tags are
+still accepted.
+
+Search the entire repository for stale references to the previous Whisper
+version. Distinguish historical benchmark provenance from active defaults:
+do not change historical claims unless the benchmarks are actually rerun.
+
+## Local runtime validation
+
+The repository's `lib/` directory is ignored and may be updated.
+
+Upgrade the local ignored library using Bucky's installer and the exact
+bucky-builder artifact, for example:
+
+    go run . install \
+        -lib "$PWD/lib" \
+        -p metal \
+        -v <WHISPER_VERSION> \
+        -u \
+        -q
+
+Adapt the processor for the current host if necessary.
+
+Verify:
+
+- the local library was replaced
+- `whisper.Version()` reports the expected version without the leading `v`
+- all required symbols load
+- FFI struct-size/default-parameter tests pass
+- model loading and transcription tests pass when fixtures are available
+
+Do not validate only against a differently packaged Homebrew library when the
+Bucky artifact can be downloaded.
+
+## Benchmarks
+
+Rerun every result recorded in `BENCHMARKS.md` using the exact local library
+installed above:
+
+1. End-to-end JFK transcription:
+
+   BUCKY_LIB="$PWD/lib" \
+    BUCKY_BENCH_MODEL="$HOME/models/ggml-tiny.bin" \
+   BUCKY_TEST_AUDIO="$PWD/samples/jfk.wav" \
+    go test -count=1 \
+        -bench=BenchmarkFullJFK \
+        -benchtime=10x \
+        -run='^$' \
+    ./pkg/whisper/
+
+2. Upstream memcpy benchmark through `whisper.BenchMemcpyStr(4)`.
+
+3. Upstream matrix-multiplication benchmark through
+   `whisper.BenchGGMLMulMatStr(4)`.
+
+4. Pure-Go audio benchmarks:
+
+   BUCKY_TEST_AUDIO="$PWD/samples/jfk.wav" \
+    go test -count=1 \
+        -bench=. \
+        -benchtime=2s \
+        -run='^$' \
+    -benchmem \
+    ./pkg/audio/
+
+Update `BENCHMARKS.md` with the actual output:
+
+- artifact provenance
+- end-to-end `ns/op`, audio duration, and RTF
+- memcpy results
+- selected matrix results
+- audio `ns/op`, B/op, allocations, and correctly recalculated percentages
+
+Keep or improve exact reproduction instructions. Never change only the
+Whisper version label while retaining measurements from the previous
+library.
+
+## Bucky release version
+
+Set Bucky's reported version to <BUCKY_VERSION> in `version.go`.
+
+Update the version test to assert the exact expected value rather than merely
+checking that the value is non-empty.
+
+Do not create, move, force-update, or push a Git tag without explicit
+approval.
+
+## Verification
+
+After all changes, run:
+
+    gofmt -s -w <changed Go files>
+    go vet ./...
+    staticcheck ./...
+    go build ./...
+    go test ./...
+    gopls check <changed Go files>
+    git diff --check
+
+Also run the `pkg/whisper` tests with `BUCKY_LIB="$PWD/lib"` so they exercise
+the newly installed Whisper library.
+
+Do not suppress diagnostics. Report skipped tests and missing model/audio/VAD
+fixtures honestly.
+
+## Release notes
+
+Produce Markdown release notes for <BUCKY_VERSION> using the requested
+baseline tag through <BUCKY_VERSION>, not merely the immediately preceding
+commit.
+
+Include, when applicable:
+
+- the whisper.cpp upgrade
+- platform artifact/download changes
+- FFI and ABI changes or explicit compatibility confirmation
+- dependency upgrades
+- benchmark results
+- regression coverage
+- Bucky version reporting
+- compatibility and breaking-change information
+- upgrade commands
+- a full changelog URL
+
+Use this upgrade command:
+
+    go install github.com/ardanlabs/bucky@<BUCKY_VERSION>
+    bucky install -u -lib ./lib
+
+Copy the final Markdown release notes into the macOS clipboard with `pbcopy`
+and verify the clipboard heading.
+
+## Final report
+
+Summarize:
+
+- files changed
+- whether FFI changes were required
+- the installed local library version
+- benchmark highlights
+- verification results
+- release/tag state
+- confirmation that the release notes are in the clipboard

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,14 +1,15 @@
 # Benchmarks
 
 Performance numbers for `pkg/whisper`. Recorded on Apple M5 Max
-(darwin/arm64) with the Metal backend baked into the upstream
-`whisper-v1.9.1-xcframework.zip`. The Go benchmark and the upstream
-ggml/memcpy helpers all run against the same `lib/libwhisper.dylib`.
+(darwin/arm64) with the Metal backend from bucky-builder's
+`whisper-v1.9.2-bin-darwin-metal-universal.zip`. The Go benchmark and
+the upstream ggml/memcpy helpers all run against the same
+`lib/libwhisper.dylib` installed by Bucky.
 
 Reproduce with:
 
 ```
-make download-whisper.cpp           # populates ./lib
+make download-whisper.cpp VERSION=v1.9.2 # populates ./lib
 make download-models                # populates ~/models
 make bench                          # BUCKY_BENCH_MODEL=ggml-tiny by default
 ```
@@ -28,9 +29,9 @@ make bench                          # BUCKY_BENCH_MODEL=ggml-tiny by default
 
 ## End-to-end transcription (greedy)
 
-| Model     | Backend | b.N |      ns/op | audio_s |    RTF |
-| --------- | ------- | --: | ---------: | ------: | -----: |
-| ggml-tiny | Metal   |  10 | 27,774,842 |   11.00 | 0.0025 |
+| Model     | Backend | b.N |      ns/op | audio_s |      RTF |
+| --------- | ------- | --: | ---------: | ------: | -------: |
+| ggml-tiny | Metal   |  10 | 28,971,246 |   11.00 | 0.002634 |
 
 Run command:
 
@@ -42,7 +43,7 @@ go test -bench=BenchmarkFullJFK -benchtime=10x -run='^$' ./pkg/whisper/
 ```
 
 The first un-timed warm-up dominates total wall time (~5–6 s) because of
-Metal library compilation; warm runs are ~28 ms for 11 s of audio. To
+Metal library compilation; warm runs are ~29 ms for 11 s of audio. To
 record numbers across `tiny`, `base`, `small`, etc., re-run with a
 different `BUCKY_BENCH_MODEL`.
 
@@ -55,27 +56,54 @@ useful for comparing backends or hosts without loading a model.
 ### `whisper_bench_memcpy_str(4)` — Apple M5 Max
 
 ```
-memcpy:   61.08 GB/s (heat-up)
-memcpy:   69.29 GB/s ( 1 thread)
-memcpy:   67.17 GB/s ( 1 thread)
-memcpy:  119.11 GB/s ( 2 thread)
-memcpy:  159.51 GB/s ( 3 thread)
-memcpy:  167.28 GB/s ( 4 thread)
+memcpy:   59.92 GB/s (heat-up)
+memcpy:   70.04 GB/s ( 1 thread)
+memcpy:   70.25 GB/s ( 1 thread)
+memcpy:  120.94 GB/s ( 2 thread)
+memcpy:  159.82 GB/s ( 3 thread)
+memcpy:  171.06 GB/s ( 4 thread)
 ```
 
 ### `whisper_bench_ggml_mul_mat_str(4)` — selected sizes
 
 | Size      |         Q4_0 |         Q8_0 |          F16 |          F32 |
 | --------- | -----------: | -----------: | -----------: | -----------: |
-| 256x256   | 112.7 GFLOPS | 229.1 GFLOPS | 201.1 GFLOPS | 138.0 GFLOPS |
-| 512x512   | 133.8 GFLOPS | 370.7 GFLOPS | 306.7 GFLOPS | 175.6 GFLOPS |
-| 1024x1024 | 138.1 GFLOPS | 428.2 GFLOPS | 359.3 GFLOPS | 183.0 GFLOPS |
-| 2048x2048 | 139.2 GFLOPS | 415.3 GFLOPS | 355.2 GFLOPS | 165.8 GFLOPS |
-| 4096x4096 | 139.4 GFLOPS | 383.2 GFLOPS | 324.0 GFLOPS | 153.9 GFLOPS |
+| 256x256   | 117.5 GFLOPS | 243.2 GFLOPS | 214.9 GFLOPS | 142.2 GFLOPS |
+| 512x512   | 140.8 GFLOPS | 368.4 GFLOPS | 312.1 GFLOPS | 172.6 GFLOPS |
+| 1024x1024 | 138.5 GFLOPS | 361.7 GFLOPS | 355.6 GFLOPS | 175.8 GFLOPS |
+| 2048x2048 | 140.8 GFLOPS | 401.6 GFLOPS | 353.3 GFLOPS | 163.0 GFLOPS |
+| 4096x4096 | 142.1 GFLOPS | 372.1 GFLOPS | 317.2 GFLOPS | 149.8 GFLOPS |
 
 Full output is produced by the `BenchMemcpyStr` / `BenchGGMLMulMatStr`
-wrappers — invoke them directly from a small driver program if you want
-the complete table.
+wrappers. The recorded values were generated with this temporary driver:
+
+```shell
+cat >/tmp/bucky-upstream-bench.go <<'EOF'
+package main
+
+import (
+    "fmt"
+    "log"
+    "os"
+
+    "github.com/ardanlabs/bucky/pkg/whisper"
+)
+
+func main() {
+    lib := os.Getenv("BUCKY_LIB")
+    if err := whisper.Load(lib); err != nil {
+        log.Fatal(err)
+    }
+    if err := whisper.Init(lib); err != nil {
+        log.Fatal(err)
+    }
+    fmt.Print(whisper.BenchMemcpyStr(4))
+    fmt.Print(whisper.BenchGGMLMulMatStr(4))
+}
+EOF
+BUCKY_LIB=$PWD/lib go run /tmp/bucky-upstream-bench.go
+rm /tmp/bucky-upstream-bench.go
+```
 
 ## Audio decode (pure Go, no FFI)
 
@@ -87,15 +115,15 @@ the benchmarks.
 
 | Benchmark                |   ns/op |      B/op | allocs/op |           vs allocating |
 | ------------------------ | ------: | --------: | --------: | ----------------------: |
-| `BenchmarkDecodeWAV`     | 158,812 | 1,056,910 |         9 |                baseline |
-| `BenchmarkDecodeWAVInto` | 129,963 |   352,393 |         8 | **-18% time, -67% mem** |
-| `BenchmarkDecode`        | 160,447 | 1,057,029 |        13 |                baseline |
-| `BenchmarkDecodeInto`    | 131,283 |   352,513 |        12 | **-18% time, -67% mem** |
+| `BenchmarkDecodeWAV`     | 152,754 | 1,056,909 |         9 |                baseline |
+| `BenchmarkDecodeWAVInto` | 128,165 |   352,393 |         8 | **-16% time, -67% mem** |
+| `BenchmarkDecode`        | 151,468 | 1,057,028 |        13 |                baseline |
+| `BenchmarkDecodeInto`    | 128,190 |   352,513 |        12 | **-15% time, -67% mem** |
 
 The `Into` variants eliminate the per-call `[]float32` output allocation
-(~705 KB for an 11 s clip). The remaining 352 KB is the internal `[]byte`
-WAV chunk read by `readWAVData` and could be pooled in a future change if
-needed.
+(~705 KB for an 11 s clip), reducing runtime by 15–16% in this run. The
+remaining 352 KB is the internal `[]byte` WAV chunk read by `readWAVData`
+and could be pooled in a future change if needed.
 
 Run command:
 

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -5,6 +5,13 @@ import (
 	"testing"
 )
 
+func TestDefaultWhisperVersion(t *testing.T) {
+	const want = "v1.9.2"
+	if DefaultWhisperVersion != want {
+		t.Errorf("DefaultWhisperVersion = %q, want %q", DefaultWhisperVersion, want)
+	}
+}
+
 func TestVersionIsValid(t *testing.T) {
 	tests := []struct {
 		version string

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package main
 
-const currentVersion = "1.0.3"
+const currentVersion = "1.0.8"
 
 // Version returns the current version of the bucky package.
 func Version() string {

--- a/version_test.go
+++ b/version_test.go
@@ -5,9 +5,8 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	version := Version()
-	if version == "" {
-		t.Fatal("version returned an empty string, which is invalid")
+	const want = "1.0.8"
+	if got := Version(); got != want {
+		t.Errorf("Version() = %q, want %q", got, want)
 	}
-	t.Logf("version returned: %s", version)
 }


### PR DESCRIPTION
## What's Changed
Bucky v1.0.8 rolls up all changes since v1.0.6, including the whisper.cpp v1.9.2 upgrade, refreshed Go dependencies, updated benchmarks, and corrected release-version reporting.