### PR TITLE
Release 1.1.1

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package main
 
-const currentVersion = "1.1.0"
+const currentVersion = "1.1.1"
 
 // Version returns the current version of the bucky package.
 func Version() string {


### PR DESCRIPTION
## What's Changed
Version 1.1.1 brings first-party Windows CUDA bundles from `ardanlabs/bucky-builder`, giving current Windows GPU installations the same versioned build source and artifact naming used across Bucky's other supported platforms. It also preserves upstream fallback behavior for older whisper.cpp releases and updates installation documentation to reflect the unified distribution model.